### PR TITLE
Revert to using "on: push"

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -1,7 +1,7 @@
 name: Continuous Delivery
 on:
   workflow_dispatch:
-  create:
+  push:
     tags:
       - "*"
 


### PR DESCRIPTION
Reverting to using "on: push" lets us see which tags started the workflow action under the [actions](https://github.com/HelikarLab/COMO/actions) tab