### PR TITLE
Undo caching

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -74,8 +74,6 @@ jobs:
           file: ./Dockerfile
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
 


### PR DESCRIPTION
This removes the caching that was enabled previously, as building performs much slower with cache enabled