### PR TITLE
Set Troppo Source

### DIFF
--- a/main/como/__init__.py
+++ b/main/como/__init__.py
@@ -4,7 +4,7 @@ from como.project import Config
 from como.utils import stringlist_to_list
 
 __all__ = ["stringlist_to_list", "Config"]
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 
 def return_placeholder_data() -> pd.DataFrame:

--- a/main/como/create_context_specific_model.py
+++ b/main/como/create_context_specific_model.py
@@ -316,8 +316,7 @@ def _build_with_imat(
         exp_thresholds=expr_thesh,
         core=force_gene_ids,
         epsilon=0.01,
-        solver=solver.upper()z
-    ,
+        solver=solver.upper(),
     )
     algorithm = IMAT(s_matrix, np.array(lb), np.array(ub), properties)
     context_rxns: npt.NDArray = algorithm.run()

--- a/main/como/create_context_specific_model.py
+++ b/main/como/create_context_specific_model.py
@@ -520,7 +520,14 @@ def _build_model(  # noqa: C901
     elif recon_algorithm == Algorithm.IMAT:
         context_model_cobra: cobra.Model
         context_model_cobra, flux_df = _build_with_imat(
-            reference_model, s_matrix, lb, ub, expr_vector, exp_thresh, idx_force
+            reference_model,
+            s_matrix,
+            lb,
+            ub,
+            expr_vector,
+            exp_thresh,
+            idx_force,
+            solver=solver,
         )
         imat_reactions = flux_df.rxn
         model_reactions = [reaction.id for reaction in context_model_cobra.reactions]

--- a/main/como/create_context_specific_model.py
+++ b/main/como/create_context_specific_model.py
@@ -419,7 +419,12 @@ def _build_model(  # noqa: C901
     force excluded even if they meet GPR association requirements using the force exclude file.
     """
     config = Config()
-    cobra.Configuration().solver = solver.lower()
+
+    cobra_config = cobra.Configuration()
+    print(cobra_config.solver)
+    cobra_config.solver = solver.lower()
+    print(cobra_config.solver)
+
     reference_model: cobra.Model
     match general_model_file.suffix:
         case ".mat":

--- a/main/como/create_context_specific_model.py
+++ b/main/como/create_context_specific_model.py
@@ -316,7 +316,7 @@ def _build_with_imat(
         exp_thresholds=expr_thesh,
         core=force_gene_ids,
         epsilon=0.01,
-        solver=solver,
+        solver=solver.upper(),
     )
     algorithm = IMAT(s_matrix, np.array(lb), np.array(ub), properties)
     context_rxns: npt.NDArray = algorithm.run()

--- a/main/como/create_context_specific_model.py
+++ b/main/como/create_context_specific_model.py
@@ -316,7 +316,8 @@ def _build_with_imat(
         exp_thresholds=expr_thesh,
         core=force_gene_ids,
         epsilon=0.01,
-        solver=solver.upper(),
+        solver=solver.upper()z
+    ,
     )
     algorithm = IMAT(s_matrix, np.array(lb), np.array(ub), properties)
     context_rxns: npt.NDArray = algorithm.run()
@@ -426,12 +427,6 @@ def _build_model(  # noqa: C901
     force excluded even if they meet GPR association requirements using the force exclude file.
     """
     config = Config()
-
-    cobra_config = cobra.Configuration()
-    print(cobra_config.solver)
-    cobra_config.solver = solver.lower()
-    print(cobra_config.solver)
-
     reference_model: cobra.Model
     match general_model_file.suffix:
         case ".mat":

--- a/main/como/create_context_specific_model.py
+++ b/main/como/create_context_specific_model.py
@@ -308,9 +308,16 @@ def _build_with_imat(
     expr_vector: npt.NDArray,
     expr_thesh: tuple[float, float],
     force_gene_ids: Sequence[int],
+    solver: str,
 ) -> (cobra.Model, pd.DataFrame):
     expr_vector = np.array(expr_vector)
-    properties = IMATProperties(exp_vector=expr_vector, exp_thresholds=expr_thesh, core=force_gene_ids, epsilon=0.01)
+    properties = IMATProperties(
+        exp_vector=expr_vector,
+        exp_thresholds=expr_thesh,
+        core=force_gene_ids,
+        epsilon=0.01,
+        solver=solver,
+    )
     algorithm = IMAT(s_matrix, np.array(lb), np.array(ub), properties)
     context_rxns: npt.NDArray = algorithm.run()
     fluxes: pd.Series = algorithm.sol.to_series()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "openpyxl>=3.1.5",
     "aiofiles>=24.1.0",
     "aioftp>=0.23.1",
-    "git+https://github.com/JoshLoecker/troppo@feat/allow-setting-solver",
-    "git+https://github.com/JoshLoecker/cobamp@update_packages",
+    "troppo@git+https://github.com/JoshLoecker/troppo@feat/allow-setting-solver",
+    "cobamp@git+https://github.com/JoshLoecker/cobamp@update_packages",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "openpyxl>=3.1.5",
     "aiofiles>=24.1.0",
     "aioftp>=0.23.1",
-    "troppo",
-    "cobamp",
+    "git+https://github.com/JoshLoecker/troppo@feat/allow-setting-solver",
+    "git+https://github.com/JoshLoecker/cobamp@update_packages",
 ]
 
 [build-system]
@@ -47,6 +47,6 @@ dev-dependencies = [
     "pytest-cov>=6.0.0",
 ]
 
-[tool.uv.sources]
-troppo = { git = "https://github.com/JoshLoecker/troppo", branch = "feat/allow-setting-solver" }
-cobamp = { git = "https://github.com/JoshLoecker/cobamp", branch = "update_packages" }
+#[tool.uv.sources]
+#troppo = { git = "https://github.com/JoshLoecker/troppo", branch = "feat/allow-setting-solver" }
+#cobamp = { git = "https://github.com/JoshLoecker/cobamp", branch = "update_packages" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,6 @@ dev-dependencies = [
     "pytest-cov>=6.0.0",
 ]
 
-#[tool.uv.sources]
-#troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "update_dependencies" }
-#cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }
+[tool.uv.sources]
+troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "update_dependencies" }
+cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "openpyxl>=3.1.5",
     "aiofiles>=24.1.0",
     "aioftp>=0.23.1",
-#    "troppo",
-#    "cobamp",
+    "troppo",
+    "cobamp",
 ]
 
 [build-system]
@@ -47,6 +47,6 @@ dev-dependencies = [
     "pytest-cov>=6.0.0",
 ]
 
-[tool.uv.sources]
+#[tool.uv.sources]
 #troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "update_dependencies" }
 #cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "aiofiles>=24.1.0",
     "aioftp>=0.23.1",
     "troppo@git+https://github.com/JoshLoecker/troppo@feat/allow-setting-solver",
-    "cobamp@git+https://github.com/JoshLoecker/cobamp@update_packages",
+    "cobamp@git+https://github.com/JoshLoecker/cobamp@master",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "openpyxl>=3.1.5",
     "aiofiles>=24.1.0",
     "aioftp>=0.23.1",
-    "troppo",
-    "cobamp",
+#    "troppo",
+#    "cobamp",
 ]
 
 [build-system]
@@ -48,5 +48,5 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "update_dependencies" }
-cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }
+#troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "update_dependencies" }
+#cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "update_dependencies" }
+troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "feat/allow-setting-solver" }
 cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "openpyxl>=3.1.5",
     "aiofiles>=24.1.0",
     "aioftp>=0.23.1",
-    "troppo@git+https://github.com/JoshLoecker/troppo@feat/allow-setting-solver",
+    "troppo@git+https://github.com/JoshLoecker/troppo@master",
     "cobamp@git+https://github.com/JoshLoecker/cobamp@master",
 ]
 
@@ -46,7 +46,3 @@ dev-dependencies = [
     "hypothesis>=6.122.1",
     "pytest-cov>=6.0.0",
 ]
-
-#[tool.uv.sources]
-#troppo = { git = "https://github.com/JoshLoecker/troppo", branch = "feat/allow-setting-solver" }
-#cobamp = { git = "https://github.com/JoshLoecker/cobamp", branch = "update_packages" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-troppo = { git = "https://github.com/JoshLoecker/troppo", rev = "feat/allow-setting-solver" }
-cobamp = { git = "https://github.com/JoshLoecker/cobamp", rev = "update_packages" }
+troppo = { git = "https://github.com/JoshLoecker/troppo", branch = "feat/allow-setting-solver" }
+cobamp = { git = "https://github.com/JoshLoecker/cobamp", branch = "update_packages" }


### PR DESCRIPTION
Troppo does not allow setting the solver, while cobamp does. This modifies the source of troppo to be JoshLoecker/troppo, where I have allowed setting a solver in iMAT, which will trickle down to cobamp