### PR TITLE
Move `gurobipy` to optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "COMO"
 dynamic = ["version"]
@@ -8,7 +12,6 @@ dependencies = [
     "cobamp@git+https://github.com/JoshLoecker/cobamp@master",
     "cobra>=0.28.0",
     "fast-bioservices>=0.3.9",
-    "gurobipy>=11.0",
     "kaleido==0.2.1",
     "loguru>=0.7.2",
     "openpyxl>=3.1.5",
@@ -24,14 +27,21 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-interactive = [
+gurobi = [ "gurobipy>=10.0.0" ]
+interactive =   [
     "ipython>=8.0.0",
-    "jupyterlab>=4.3.2",
+    "jupyterlab>=4.3.2"
+]
+dev = [
+    "commitlint>=1.3.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest>=8.3.3",
+    "ruff>=0.8.0",
+    "hypothesis>=6.122.1",
+    "pytest-cov>=6.0.0",
+    "commitizen>=4.1.0",
 ]
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
 
 [tool.hatch.version]
 path = "main/como/__init__.py"
@@ -44,18 +54,6 @@ allow-direct-references = true
 
 [tool.pytest.ini_options]
 pythonpath = [ "main/src" ]
-
-[tool.uv]
-dev-dependencies = [
-    "commitlint>=1.3.0",
-    "pytest-asyncio>=0.24.0",
-    "pytest>=8.3.3",
-    "ruff>=0.8.0",
-    "hypothesis>=6.122.1",
-    "pytest-cov>=6.0.0",
-    "commitizen>=4.1.0",
-    "cz-conventional-gitmoji>=0.6.1",
-]
 
 [tool.commitizen]
 name = "cz_conventional_commits"


### PR DESCRIPTION
Gurobi can now optionally be installed using `pip install como[gurobi]` (or your installer's equivalent)